### PR TITLE
Update AccessToken.php

### DIFF
--- a/src/Wechat/AccessToken.php
+++ b/src/Wechat/AccessToken.php
@@ -50,7 +50,7 @@ class AccessToken
     {
         $this->appId     = $appId;
         $this->appSecret = $appSecret;
-        $this->cacheKey = $this->cacheKey.'.'.$appId;
+        $this->cacheKey = $this->cacheKey.'.'.$appId.'.'.$appSecret;
         $this->cache     = new Cache($appId);
     }
 


### PR DESCRIPTION
企业微信中取消了以前的管理组,采用各应用独立appSecret,
如果使用api编辑通讯录,同时使用自建应用,cacheKey应缓存各自应用的access_token.