### PR TITLE
Update Http.php

### DIFF
--- a/src/Wechat/Utils/Http.php
+++ b/src/Wechat/Utils/Http.php
@@ -170,7 +170,7 @@ class Http
                 $params[$index] = $this->createCurlFile($file);
             }
 
-            version_compare(PHP_VERSION, '5.5', '<') || curl_setopt($this->curl, CURLOPT_SAFE_UPLOAD, false);
+            version_compare(PHP_VERSION, '5.5', '>') || curl_setopt($this->curl, CURLOPT_SAFE_UPLOAD, false);
 
             curl_setopt($this->curl, CURLOPT_POST, 1);
             curl_setopt($this->curl, CURLOPT_POSTFIELDS, $params);


### PR DESCRIPTION
同.https://github.com/overtrue/wechat/commit/2d640e03ef287a90409e653e0d1854aa9d78e353. php7版本禁用 CURLOPT_SAFE_UPLOAD 参数的问题.

烦请,合并后在发布一个release,谢谢.